### PR TITLE
Fix Docker workflow metadata action tags format

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=short
-            latest
+            type=raw,value=latest
 
       - name: Build and push Docker image (MCP Obsidian)
         uses: docker/build-push-action@v6
@@ -64,13 +64,13 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=sha,format=short
-            latest
+            type=raw,value=latest
   
       - name: Build and push Docker image (VNC Obsidian)
         uses: docker/build-push-action@v6
         with:
           context: ./dockerize
-          file: dockerize/Dockerfile
+          file: ./dockerize/Dockerfile
           push: true
           tags: ${{ steps.metaVnc.outputs.tags }}
           labels: ${{ steps.metaVnc.outputs.labels }}


### PR DESCRIPTION
## Summary

This PR fixes the GitHub Actions failure in the Docker publishing workflow (run #15438796226).

## Root Cause

The failure was caused by incorrect tag format in the `docker/metadata-action@v5` configuration. The workflow was using:

```yaml
tags: |
  type=ref,event=branch
  type=semver,pattern={{version}}
  type=sha,format=short
  latest  # ❌ Incorrect format
```

## Fix

Changed the `latest` tag to use the proper format required by docker/metadata-action@v5:

```yaml
tags: |
  type=ref,event=branch
  type=semver,pattern={{version}}
  type=sha,format=short
  type=raw,value=latest  # ✅ Correct format
```

## Changes

- Fixed tag format for both MCP Obsidian and VNC Obsidian Docker images
- Ensured correct Dockerfile path for VNC Obsidian build

## Testing

- Local build works successfully (verified with `bun install` and `bun run build`)
- The docker/metadata-action documentation confirms this is the correct format
- This should resolve the step 7 failure in the GitHub Actions workflow

## Related

- Fixes GitHub Actions run: https://github.com/OleksandrKucherenko/mcp-obsidian-via-rest/actions/runs/15438796226
- Commit that introduced the issue: 06b05d8b8eb90140c92023d5f1433bbbe4ee3630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image publishing workflow to clarify tag specification and Dockerfile path for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->